### PR TITLE
Fixed ReDoS (Regex Denial of Service)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 const ipRegex = require('ip-regex');
 const tlds = require('tlds');
+const RE2 = require('re2');
 
 module.exports = options => {
 	options = {
@@ -18,5 +19,5 @@ module.exports = options => {
 	const path = '(?:[/?#][^\\s"]*)?';
 	const regex = `(?:${protocol}|www\\.)${auth}(?:localhost|${ip}|${host}${domain}${tld})${port}${path}`;
 
-	return options.exact ? new RegExp(`(?:^${regex}$)`, 'i') : new RegExp(regex, 'ig');
+	return options.exact ? new RE2(`(?:^${regex}$)`, 'i') : new RE2(regex, 'ig');
 };

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 	],
 	"dependencies": {
 		"ip-regex": "^4.1.0",
+		"re2": "^1.15.4",
 		"tlds": "^1.203.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-maven-url-regex

### ⚙️ Description *

The project `url-regex` was validating URLs with a regex vulnerable to **ReDoS** (Regex Denial of Service) with `RegExp()`.

### 💻 Technical Description *

The implemented Regex patterns to validate URLs are vulnerable to ReDoS:

```javascript
const protocol = `(?:(?:[a-z]+:)?//)${options.strict ? '' : '?'}`;
const auth = '(?:\\S+(?::\\S*)?@)?';
const ip = ipRegex.v4().source;
const host = '(?:(?:[a-z\\u00a1-\\uffff0-9][-_]*)*[a-z\\u00a1-\\uffff0-9]+)';
const domain = '(?:\\.(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)*';
const tld = `(?:\\.${options.strict ? '(?:[a-z\\u00a1-\\uffff]{2,})' : `(?:${tlds.sort((a, b) => b.length - a.length).join('|')})`})\\.?`;
const port = '(?::\\d{2,5})?';
const path = '(?:[/?#][^\\s"]*)?';
const regex = `(?:${protocol}|www\\.)${auth}(?:localhost|${ip}|${host}${domain}${tld})${port}${path}`;
```

Using a long string to make it pass through this regex will lead to **Denial of Service**.

### 🐛 Proof of Concept (PoC) *

```javsascript
require('url-regex')({ strict: false }).test('018137.113.215.4074.138.129.172220.179.206.94180.213.144.175250.45.147.1364868726sgdm6nohQ')
```

### 🔥 Proof of Fix (PoF) *

![Screenshot from 2020-08-18 21-12-45](https://user-images.githubusercontent.com/26198477/90534886-e49c9600-e197-11ea-8b42-1e095e7a9ec2.png)

As the used Regex is perfect to validate URLs but just vulnerable to ReDoS, I implemented [`node-re2`](https://www.npmjs.com/package/re2) instead of the JavaScript `RegExp()` function as `re2` can convert a vulnerable Regex pattern to a safe one preventing any backtracking regular expressions/attacks.

:books: **Reference:**
- https://www.npmjs.com/package/re2#standard-features
- https://github.com/kevva/url-regex/issues/70#issuecomment-619702296

### 👍 User Acceptance Testing (UAT)

Replaced the usage of `RegExp()` function with a safer regex binding [`node-re2`](https://www.npmjs.com/package/re2#standard-features).
